### PR TITLE
Command logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
 		"jsxSingleQuote": false,
 		"bracketSpacing": true,
 		"trailingComma": "all",
-		"printWidth": 120,
+		"printWidth": 140,
 		"tabWidth": 4,
 		"arrowParens": "avoid",
 		"endOfLine": "lf"

--- a/src/commands/registerBotCommands.js
+++ b/src/commands/registerBotCommands.js
@@ -2,7 +2,7 @@ import { greetingMessage } from '../greetings.js'
 import { getMainMenu } from '../components/keyboards/keyboards.js'
 import { getWeek, isWeekEven } from '../components/definitionOfWeek.js'
 import { contactInfo } from '../contactMe.js'
-import { handlerReplyBtn } from '../components/handlers/buttonHandler.js'
+import { getScheduleWeek } from '../components/handlers/scheduleHandler.js'
 
 /** @param {import('telegraf').Telegraf} bot*/
 export default bot => {
@@ -13,7 +13,11 @@ export default bot => {
 		const greetingName = userName || pseudonym
 		ctx.reply(`Привет, ${greetingName}!\n${greetingMessage}`, getMainMenu())
 	}
-	const getWeekScheduleHandler = ctx => handlerReplyBtn.scheduleWeek(ctx)
+	const getWeekScheduleHandler = shiftWeek => {
+		return ctx => {
+			ctx.replyWithHTML(getScheduleWeek(shiftWeek))
+		}
+	}
 	const getWeekInfoHandler = ctx => {
 		const date = new Date()
 		const week = isWeekEven(date) ? 'Четная' : 'Нечетная'
@@ -23,8 +27,9 @@ export default bot => {
 
 	const commands = [
 		{ command: 'start', handler: startHandler, description: 'Запустить бота' },
-		{ command: 'schedule', handler: getWeekScheduleHandler, description: 'Посмотреть расписание' },
 		{ command: 'week', handler: getWeekInfoHandler, description: 'Какая сейчас неделя' },
+		{ command: 'week_schedule', handler: getWeekScheduleHandler(), description: 'Расписание на эту неделю' },
+		{ command: 'next_week_schedule', handler: getWeekScheduleHandler(1), description: 'Расписание на следующую неделю' },
 		{ command: 'support', handler: getSupportHandler, description: 'Написать в поддержку' },
 	]
 

--- a/src/components/handlers/buttonHandler.js
+++ b/src/components/handlers/buttonHandler.js
@@ -2,16 +2,16 @@ import { weekdaySelector, createUrlBtn } from '../keyboards/keyboards.js'
 import { getDayOfWeek } from './scheduleHandler.js'
 
 export const handlerReplyBtn = {
-	scheduleToday: ctx => {
+	getScheduleToday: ctx => {
 		ctx.replyWithHTML(getDayOfWeek(), createUrlBtn())
 	},
-	scheduleForTomorrow: ctx => {
+	getScheduleForTomorrow: ctx => {
 		ctx.replyWithHTML(getDayOfWeek(1), createUrlBtn())
 	},
-	scheduleWeek: ctx => {
+	getScheduleWeek: ctx => {
 		ctx.replyWithHTML('<b>Выберите день:</b>', weekdaySelector())
 	},
-	scheduleNextWeek: ctx => {
+	getScheduleNextWeek: ctx => {
 		ctx.replyWithHTML('<b>Выберите день:</b>', weekdaySelector(true))
 	},
 }

--- a/src/components/handlers/scheduleHandler.js
+++ b/src/components/handlers/scheduleHandler.js
@@ -11,7 +11,7 @@ const MESSAGE = '<b>🎉 Занятий нет, можно отдыхать.</b>
  *
  * @returns {string} - 	  The formatted lesson information for display.
  */
-const formatLessons = (type, { start, end, title, description, audience }) => {
+const getFormatLessons = (type, { start, end, title, description, audience }) => {
 	// Extract start and end times
 	const startTime = start.slice(11, 16)
 	const endTime = end.slice(11, 16)
@@ -29,11 +29,11 @@ const formatLessons = (type, { start, end, title, description, audience }) => {
 /**
  * Determines the type of lesson (lecture or practice) based on the current week.
  *
- * @param {object} event - An object containing information about the lesson.
+ * @param {object} event - 		 An object containing information about the lesson.
  *
  * @param {number} currentWeek - The current week number.
  *
- * @returns {string|null} - The type of the lesson, can be 'Лекция', 'Практика', or null if not found.
+ * @returns {string|null} - 	 The type of the lesson, can be 'Лекция', 'Практика', or null if not found.
  */
 export const getLessonType = (event, currentWeek) => {
 	// Destructure the event object to extract the lection and practical arrays
@@ -72,7 +72,7 @@ export const getLessonsInfo = (targetDay, shouldShiftWeek) => {
 		// Iterate through all lessons for the specified day
 		.map(event => {
 			const lessonType = getLessonType(event, currentWeek)
-			return lessonType ? formatLessons(lessonType, event) : null
+			return lessonType ? getFormatLessons(lessonType, event) : null
 		})
 		// Remove all null values that may have occurred if the lesson type was not determined
 		.filter(info => info !== null)

--- a/src/components/handlers/scheduleHandler.js
+++ b/src/components/handlers/scheduleHandler.js
@@ -108,11 +108,21 @@ export const getDayOfWeek = (shiftDay = 0) => {
 	// Retrieve the schedule for the specified day based on the day index
 	return getLessonsInfo(DAY_OF_WEEK[dayIndex], shouldShiftWeek)
 }
-
+/**
+ * Function to get the weekly schedule.
+ * @param {number} shiftWeek - Shift of the week
+ * @returns {string} - Line with the full weekly schedule
+ */
 export const getScheduleWeek = shiftWeek => {
+	// Filter the days of the week, excluding Sunday and Saturday,
+	// then convert each day of the week into a string with its schedule.
 	const scheduleWeek = DAY_OF_WEEK.filter(element => element !== 'Sunday' && element !== 'Saturday').map(element => {
+		// Get information about classes for the current day of the week
+		// and delete extra spaces from the beginning and end of the string.
 		const dayOfWeek = getLessonsInfo(element, shiftWeek).trim()
+		// Return a string with information about the day of the week and its schedule.
 		return `\n🛑 <b>${element}</b>:\n\n ${dayOfWeek}\n`
 	})
+	// Combine the rows with the schedule for each day of the week into a single row and return the result.
 	return scheduleWeek.join('')
 }

--- a/src/components/handlers/scheduleHandler.js
+++ b/src/components/handlers/scheduleHandler.js
@@ -108,3 +108,11 @@ export const getDayOfWeek = (shiftDay = 0) => {
 	// Retrieve the schedule for the specified day based on the day index
 	return getLessonsInfo(DAY_OF_WEEK[dayIndex], shouldShiftWeek)
 }
+
+export const getScheduleWeek = shiftWeek => {
+	const scheduleWeek = DAY_OF_WEEK.filter(element => element !== 'Sunday' && element !== 'Saturday').map(element => {
+		const dayOfWeek = getLessonsInfo(element, shiftWeek).trim()
+		return `\n🛑 <b>${element}</b>:\n\n ${dayOfWeek}\n`
+	})
+	return scheduleWeek.join('')
+}

--- a/src/index.js
+++ b/src/index.js
@@ -9,13 +9,13 @@ const bot = new Telegraf(process.env.TELEGRAM_TOKEN, { polling: true })
 
 registerBotCommands(bot)
 
-bot.hears('Сегодня', handlerReplyBtn.scheduleToday)
+bot.hears('Сегодня', handlerReplyBtn.getScheduleToday)
 
-bot.hears('Завтра', handlerReplyBtn.scheduleForTomorrow)
+bot.hears('Завтра', handlerReplyBtn.getScheduleForTomorrow)
 
-bot.hears('Текущая неделя', handlerReplyBtn.scheduleWeek)
+bot.hears('Текущая неделя', handlerReplyBtn.getScheduleWeek)
 
-bot.hears('Следующая неделя', handlerReplyBtn.scheduleNextWeek)
+bot.hears('Следующая неделя', handlerReplyBtn.getScheduleNextWeek)
 
 addButtonAction(bot, 'btnMon', getLessonsInfo('Monday'))
 addButtonAction(bot, 'btnTue', getLessonsInfo('Tuesday'))


### PR DESCRIPTION
@Ilanaya Hey,look,please.
I left the option to select the week when you click the "Current week" and "Next Week" buttons.
![image](https://github.com/mkangoo/Telegram-bot-schedule/assets/121447049/289d2918-b5bf-4ed3-8bab-4cd9460ad615)
I added two commands 'week_schedule' and 'next_week_schedule' that show the full schedule.
`week_schedule`
![image](https://github.com/mkangoo/Telegram-bot-schedule/assets/121447049/be2e53d2-4953-40f7-ad0a-4075b6cdd682)
`next_week_schedule`
![image](https://github.com/mkangoo/Telegram-bot-schedule/assets/121447049/d2cc20dc-4c44-47fd-9dc9-b4fd2a725801)

